### PR TITLE
Allow X11 capture on displays with non-zero sequence number

### DIFF
--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -146,7 +146,7 @@ export class FFmpegUtil {
       ...getAll({
         video_size: `${bounds.width}x${bounds.height}`,
         f: 'x11grab',
-        i: `:0.0+${bounds.x},${bounds.y}`
+        i: `${process.env.DISPLAY || ':0.0'}+${bounds.x},${bounds.y}`
       })
     );
 


### PR DESCRIPTION
In some cases, the X11 server can be run with non-zero sequence number. This number is available as `$DISPLAY` environment variable. This PR adds support for it. https://datacadamia.com/ssh/x11/display